### PR TITLE
Add helper for creating custom time formatters

### DIFF
--- a/src/Formatting/Time.hs
+++ b/src/Formatting/Time.hs
@@ -293,3 +293,7 @@ seconds n = later (bprint (fixed n) . abs . count)
 -- | Formatter call. Probably don't want to use this.
 fmt :: FormatTime a => Text -> a -> Text
 fmt f = T.pack . formatTime defaultTimeLocale (T.unpack f)
+
+-- | Helper for creating custom time formatters
+customTimeFmt :: FormatTime a => Text -> Format r (a -> r)
+customTimeFmt f = later (build . fmt f)


### PR DESCRIPTION
Currently there isn't a way to e.g. remove the padding from `dateSlash` or `dayOfMonth`. This PR adds a helper that lets you define custom date formats, for instance:

``` haskell
-- 5/4/2016 vs 05/04/2016 from `dateSlash`
dateSlashNoPadding = customTimeFmt "%-m/%-d/%Y"

-- 4 vs 04 from `dayOfMonth`
dayOfMonthNoPadding = customTimeFmt "%-d"
```
